### PR TITLE
feat: Add measurement interaction to ng-openlayers

### DIFF
--- a/apps/demo-ng-openlayers/src/app/app.routing.ts
+++ b/apps/demo-ng-openlayers/src/app/app.routing.ts
@@ -26,6 +26,7 @@ import { ImageStaticComponent } from './image-static/image-static.component';
 import { OverlayDemoComponent } from './overlay/overlay-demo.component';
 import { GraticuleDemoComponent } from './graticule/graticule-demo.component';
 import { DrawHoleInPolygonComponent } from './draw-hole-in-polygon/draw-hole-in-polygon.component';
+import { MeasureComponent } from './measure/measure.component';
 
 const routes: Routes = [
   { path: '', component: ExamplesListComponent },
@@ -57,6 +58,7 @@ const routes: Routes = [
       { path: 'tile-json', component: TileJsonComponent },
       { path: 'graticule', component: GraticuleDemoComponent },
       { path: 'draw-hole-in-polygon', component: DrawHoleInPolygonComponent },
+      { path: 'measure', component: MeasureComponent },
     ],
   },
   { path: '**', redirectTo: '' },

--- a/apps/demo-ng-openlayers/src/app/example-list.ts
+++ b/apps/demo-ng-openlayers/src/app/example-list.ts
@@ -141,4 +141,11 @@ export const examplesList = [
       'Example of using aol-interaction-draw-hole-in-polygon. This example shows how to draw a hole in a polygon. To remove a hole, click on the hole with Ctrl key pressed.',
     routerLink: 'draw-hole-in-polygon',
   },
+  {
+    title: 'Measure',
+    description:
+      'Example of using aol-interaction-measure. This example shows how to measure distances and areas on the map.',
+    routerLink: 'measure',
+    openLayersLink: 'https://openlayers.org/en/latest/examples/measure.html',
+  },
 ];

--- a/apps/demo-ng-openlayers/src/app/measure/measure.component.ts
+++ b/apps/demo-ng-openlayers/src/app/measure/measure.component.ts
@@ -51,6 +51,7 @@ import {
           <button (click)="setMeasureType(MeasureType.Polygon)" [class.active]="measureType === MeasureType.Polygon">
             Measure Area
           </button>
+          <button class="clear-btn" (click)="clearMeasurements()">Clear Measurements</button>
         </div>
         <div class="options">
           <label>
@@ -110,6 +111,12 @@ import {
         color: white;
         border-color: #4285f4;
       }
+      button.clear-btn {
+        background: #f44336;
+        color: white;
+        border-color: #d32f2f;
+        margin-left: auto;
+      }
       .result {
         margin-top: 10px;
         padding: 10px;
@@ -168,6 +175,13 @@ export class MeasureComponent implements AfterViewInit {
   toggleHelpTooltip() {
     if (this.measureInteraction) {
       this.measureInteraction.toggleHelpTooltip(this.showHelpTooltip);
+    }
+  }
+
+  clearMeasurements() {
+    if (this.measureInteraction) {
+      this.measureInteraction.clearMeasurements();
+      this.lastMeasurement = '';
     }
   }
 }

--- a/apps/demo-ng-openlayers/src/app/measure/measure.component.ts
+++ b/apps/demo-ng-openlayers/src/app/measure/measure.component.ts
@@ -1,0 +1,136 @@
+import { Component, ViewChild } from '@angular/core';
+import { Feature } from 'ol';
+import { CommonModule } from '@angular/common';
+import {
+  MapComponent,
+  ViewComponent,
+  LayerTileComponent,
+  SourceOsmComponent,
+  MeasureInteractionComponent,
+  MeasureType,
+} from 'ng-openlayers';
+
+@Component({
+  selector: 'app-measure',
+  standalone: true,
+  imports: [
+    CommonModule,
+    MapComponent,
+    ViewComponent,
+    LayerTileComponent,
+    SourceOsmComponent,
+    MeasureInteractionComponent,
+  ],
+  template: `
+    <div class="container">
+      <div class="map-container">
+        <aol-map width="100%" height="100%">
+          <aol-view [zoom]="4" [center]="[0, 0]"></aol-view>
+          <aol-layer-tile>
+            <aol-source-osm></aol-source-osm>
+          </aol-layer-tile>
+          <aol-interaction-measure
+            #measureInteraction
+            [type]="measureType"
+            (measureComplete)="onMeasureComplete($event)"
+          ></aol-interaction-measure>
+        </aol-map>
+      </div>
+      <div class="controls">
+        <h3>Measurement Controls</h3>
+        <div class="buttons">
+          <button
+            (click)="setMeasureType(MeasureType.LineString)"
+            [class.active]="measureType === MeasureType.LineString"
+          >
+            Measure Distance
+          </button>
+          <button (click)="setMeasureType(MeasureType.Polygon)" [class.active]="measureType === MeasureType.Polygon">
+            Measure Area
+          </button>
+        </div>
+        <div *ngIf="lastMeasurement" class="result">
+          <h4>Last Measurement:</h4>
+          <p [innerHTML]="lastMeasurement"></p>
+        </div>
+        <div class="info">
+          <h4>How to use:</h4>
+          <p>
+            Select the type of measurement (distance or area), then click on the map to start measuring. Click again to
+            add more points. Double-click to finish.
+          </p>
+          <p>Press Ctrl+Z to undo the last point.</p>
+        </div>
+      </div>
+    </div>
+  `,
+  styles: [
+    `
+      .container {
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+      }
+      .map-container {
+        flex: 1;
+        width: 100%;
+        min-height: 400px;
+      }
+      .controls {
+        padding: 10px;
+        background: #f5f5f5;
+        border-top: 1px solid #ddd;
+      }
+      .buttons {
+        display: flex;
+        gap: 10px;
+        margin-bottom: 10px;
+      }
+      button {
+        padding: 8px 16px;
+        background: #fff;
+        border: 1px solid #ccc;
+        border-radius: 4px;
+        cursor: pointer;
+      }
+      button.active {
+        background: #4285f4;
+        color: white;
+        border-color: #4285f4;
+      }
+      .result {
+        margin-top: 10px;
+        padding: 10px;
+        background: #fff;
+        border: 1px solid #ddd;
+        border-radius: 4px;
+      }
+      .info {
+        margin-top: 10px;
+        padding: 10px;
+        background: #e1f5fe;
+        border: 1px solid #81d4fa;
+        border-radius: 4px;
+      }
+    `,
+  ],
+})
+export class MeasureComponent {
+  @ViewChild('measureInteraction') measureInteraction: MeasureInteractionComponent;
+
+  measureType = MeasureType.LineString;
+  lastMeasurement: string;
+  MeasureType = MeasureType; // Make enum available in the template
+
+  onMeasureComplete(event: { feature: Feature; measure: number; formattedMeasure: string }) {
+    console.log('Measurement completed:', event);
+    this.lastMeasurement = event.formattedMeasure;
+  }
+
+  setMeasureType(type: MeasureType) {
+    this.measureType = type;
+    if (this.measureInteraction) {
+      this.measureInteraction.setMeasureType(type);
+    }
+  }
+}

--- a/libs/ng-openlayers/src/lib/interactions/draw-hole-in-polygon.ts
+++ b/libs/ng-openlayers/src/lib/interactions/draw-hole-in-polygon.ts
@@ -24,8 +24,8 @@ export interface DrawHoleInPolygonInteractionError {
 }
 
 @Component({
-    selector: 'aol-interaction-draw-hole-in-polygon',
-    template: `
+  selector: 'aol-interaction-draw-hole-in-polygon',
+  template: `
     <aol-interaction-draw
       #drawInstance
       type="Polygon"
@@ -37,7 +37,7 @@ export interface DrawHoleInPolygonInteractionError {
     >
     </aol-interaction-draw>
   `,
-    imports: [DrawInteractionComponent]
+  imports: [DrawInteractionComponent],
 })
 export class DrawHoleInPolygonInteractionComponent implements OnDestroy {
   @ViewChild('drawInstance') drawInteractionComponent: DrawInteractionComponent;

--- a/libs/ng-openlayers/src/lib/interactions/measure.component.css
+++ b/libs/ng-openlayers/src/lib/interactions/measure.component.css
@@ -1,0 +1,43 @@
+.ol-tooltip {
+  position: relative;
+  background: rgba(0, 0, 0, 0.5);
+  border-radius: 4px;
+  color: white;
+  padding: 4px 8px;
+  opacity: 0.7;
+  white-space: nowrap;
+  font-size: 12px;
+  cursor: default;
+  user-select: none;
+}
+
+.ol-tooltip-measure {
+  opacity: 1;
+  font-weight: bold;
+}
+
+.ol-tooltip-static {
+  background-color: #ffcc33;
+  color: black;
+  border: 1px solid white;
+}
+
+.ol-tooltip-measure:before,
+.ol-tooltip-static:before {
+  border-top: 6px solid rgba(0, 0, 0, 0.5);
+  border-right: 6px solid transparent;
+  border-left: 6px solid transparent;
+  content: "";
+  position: absolute;
+  bottom: -6px;
+  margin-left: -7px;
+  left: 50%;
+}
+
+.ol-tooltip-static:before {
+  border-top-color: #ffcc33;
+}
+
+.hidden {
+  display: none;
+} 

--- a/libs/ng-openlayers/src/lib/interactions/measure.component.ts
+++ b/libs/ng-openlayers/src/lib/interactions/measure.component.ts
@@ -1,0 +1,298 @@
+import { Component, EventEmitter, Input, OnDestroy, OnInit, Output, ViewChild } from '@angular/core';
+import { MapComponent } from '../map.component';
+import { Feature } from 'ol';
+import { Geometry, LineString, Polygon } from 'ol/geom';
+import { Fill, Stroke, Style } from 'ol/style';
+import { Circle as CircleStyle } from 'ol/style';
+import { DrawEvent } from 'ol/interaction/Draw';
+import { Overlay } from 'ol';
+import { unByKey } from 'ol/Observable';
+import { getArea, getLength } from 'ol/sphere';
+import VectorSource from 'ol/source/Vector';
+import VectorLayer from 'ol/layer/Vector';
+import { DrawInteractionComponent } from './draw.component';
+import { Type } from 'ol/geom/Geometry';
+
+export enum MeasureType {
+  LineString = 'LineString',
+  Polygon = 'Polygon',
+}
+
+@Component({
+  selector: 'aol-interaction-measure',
+  template: `
+    <aol-interaction-draw
+      #drawInstance
+      [type]="type"
+      [source]="source"
+      (drawEnd)="onDrawEnd($event)"
+      (drawStart)="onDrawStart($event)"
+      [style]="staticStyle"
+    >
+    </aol-interaction-draw>
+  `,
+  standalone: true,
+  styleUrls: ['./measure.component.css'],
+  imports: [DrawInteractionComponent],
+})
+export class MeasureInteractionComponent implements OnInit, OnDestroy {
+  @ViewChild('drawInstance') drawInteractionComponent: DrawInteractionComponent;
+
+  @Input() type: Type = MeasureType.LineString;
+  @Input() source?: VectorSource;
+  @Input() unit: 'metric' | 'imperial' = 'metric';
+
+  @Output() measureComplete = new EventEmitter<{ feature: Feature; measure: number; formattedMeasure: string }>();
+  @Output() measureStart = new EventEmitter<Feature>();
+
+  staticStyle = new Style({
+    fill: new Fill({
+      color: 'rgba(255, 255, 255, 0.2)',
+    }),
+    stroke: new Stroke({
+      color: 'rgba(0, 0, 0, 0.5)',
+      lineDash: [10, 10],
+      width: 2,
+    }),
+    image: new CircleStyle({
+      radius: 5,
+      stroke: new Stroke({
+        color: 'rgba(0, 0, 0, 0.7)',
+      }),
+      fill: new Fill({
+        color: 'rgba(255, 255, 255, 0.2)',
+      }),
+    }),
+  });
+
+  private measureTooltipElement: HTMLElement | null;
+  private measureTooltip: Overlay;
+  private helpTooltipElement: HTMLElement | null;
+  private helpTooltip: Overlay;
+  private sketch: Feature<Geometry> | null;
+  private listener: any;
+  private vector: VectorLayer<VectorSource>;
+
+  constructor(private map: MapComponent) {}
+
+  ngOnInit() {
+    // Create vector layer if not provided
+    if (!this.source) {
+      this.source = new VectorSource();
+      this.vector = new VectorLayer({
+        source: this.source,
+        style: {
+          'fill-color': 'rgba(255, 255, 255, 0.2)',
+          'stroke-color': '#ffcc33',
+          'stroke-width': 2,
+          'circle-radius': 7,
+          'circle-fill-color': '#ffcc33',
+        },
+      });
+      this.map.instance.addLayer(this.vector);
+    }
+
+    this.createMeasureTooltip();
+    this.createHelpTooltip();
+
+    // Add pointer move handler to show help messages
+    this.map.instance.on('pointermove', this.pointerMoveHandler);
+
+    // Handle mouseout event
+    this.map.instance.getViewport().addEventListener('mouseout', () => {
+      if (this.helpTooltipElement) {
+        this.helpTooltipElement.classList.add('hidden');
+      }
+    });
+  }
+
+  onDrawStart = (e: DrawEvent) => {
+    this.sketch = e.feature;
+    this.measureStart.emit(this.sketch);
+
+    let tooltipCoord;
+
+    this.listener = this.sketch.getGeometry()?.on('change', (evt) => {
+      const geom = evt.target;
+      let output = '';
+      let measure = 0;
+
+      if (geom instanceof Polygon) {
+        measure = getArea(geom);
+        output = this.formatArea(measure);
+        tooltipCoord = geom.getInteriorPoint().getCoordinates();
+      } else if (geom instanceof LineString) {
+        measure = getLength(geom);
+        output = this.formatLength(measure);
+        tooltipCoord = geom.getLastCoordinate();
+      }
+
+      if (this.measureTooltipElement) {
+        this.measureTooltipElement.innerHTML = output;
+        this.measureTooltip.setPosition(tooltipCoord);
+      }
+    });
+  };
+
+  onDrawEnd = (e: DrawEvent) => {
+    let measure = 0;
+    let formattedMeasure = '';
+    const geometry = e.feature.getGeometry();
+
+    if (geometry instanceof Polygon) {
+      measure = getArea(geometry);
+      formattedMeasure = this.formatArea(measure);
+    } else if (geometry instanceof LineString) {
+      measure = getLength(geometry);
+      formattedMeasure = this.formatLength(measure);
+    }
+
+    this.measureComplete.emit({
+      feature: e.feature,
+      measure,
+      formattedMeasure,
+    });
+
+    if (this.measureTooltipElement) {
+      this.measureTooltipElement.className = 'ol-tooltip ol-tooltip-static';
+      this.measureTooltip.setOffset([0, -7]);
+    }
+
+    // unset sketch and listener
+    this.sketch = null;
+    if (this.listener) {
+      unByKey(this.listener);
+    }
+
+    // Create a new tooltip
+    this.measureTooltipElement = null;
+    this.createMeasureTooltip();
+  };
+
+  private formatLength(length: number): string {
+    let output;
+    if (this.unit === 'metric') {
+      if (length > 100) {
+        output = Math.round((length / 1000) * 100) / 100 + ' km';
+      } else {
+        output = Math.round(length * 100) / 100 + ' m';
+      }
+    } else {
+      // Imperial units
+      const feetPerMeter = 3.28084;
+      const milesPerFeet = 1 / 5280;
+      const feet = length * feetPerMeter;
+
+      if (feet > 5280) {
+        output = Math.round(feet * milesPerFeet * 100) / 100 + ' mi';
+      } else {
+        output = Math.round(feet * 100) / 100 + ' ft';
+      }
+    }
+    return output;
+  }
+
+  private formatArea(area: number): string {
+    let output;
+    if (this.unit === 'metric') {
+      if (area > 10000) {
+        output = Math.round((area / 1000000) * 100) / 100 + ' km<sup>2</sup>';
+      } else {
+        output = Math.round(area * 100) / 100 + ' m<sup>2</sup>';
+      }
+    } else {
+      // Imperial units
+      const squareFeetPerSquareMeter = 10.7639;
+      const squareFeet = area * squareFeetPerSquareMeter;
+      const acresPerSquareFoot = 1 / 43560;
+
+      if (squareFeet > 43560) {
+        output = Math.round(squareFeet * acresPerSquareFoot * 100) / 100 + ' acres';
+      } else {
+        output = Math.round(squareFeet * 100) / 100 + ' ft<sup>2</sup>';
+      }
+    }
+    return output;
+  }
+
+  private pointerMoveHandler = (evt) => {
+    if (evt.dragging) {
+      return;
+    }
+
+    let helpMsg = 'Click to start measuring';
+
+    if (this.sketch) {
+      const geom = this.sketch.getGeometry();
+      if (geom instanceof Polygon) {
+        helpMsg = 'Click to continue drawing the polygon';
+      } else if (geom instanceof LineString) {
+        helpMsg = 'Click to continue drawing the line';
+      }
+    }
+
+    if (this.helpTooltipElement) {
+      this.helpTooltipElement.innerHTML = helpMsg;
+      this.helpTooltip.setPosition(evt.coordinate);
+      this.helpTooltipElement.classList.remove('hidden');
+    }
+  };
+
+  private createMeasureTooltip() {
+    if (this.measureTooltipElement) {
+      this.measureTooltipElement.remove();
+    }
+    this.measureTooltipElement = document.createElement('div');
+    this.measureTooltipElement.className = 'ol-tooltip ol-tooltip-measure';
+    this.measureTooltip = new Overlay({
+      element: this.measureTooltipElement,
+      offset: [0, -15],
+      positioning: 'bottom-center',
+      stopEvent: false,
+      insertFirst: false,
+    });
+    this.map.instance.addOverlay(this.measureTooltip);
+  }
+
+  private createHelpTooltip() {
+    if (this.helpTooltipElement) {
+      this.helpTooltipElement.remove();
+    }
+    this.helpTooltipElement = document.createElement('div');
+    this.helpTooltipElement.className = 'ol-tooltip hidden';
+    this.helpTooltip = new Overlay({
+      element: this.helpTooltipElement,
+      offset: [15, 0],
+      positioning: 'center-left',
+    });
+    this.map.instance.addOverlay(this.helpTooltip);
+  }
+
+  public setMeasureType(type: MeasureType) {
+    this.type = type;
+  }
+
+  ngOnDestroy() {
+    this.map.instance.un('pointermove', this.pointerMoveHandler);
+
+    if (this.measureTooltip) {
+      this.map.instance.removeOverlay(this.measureTooltip);
+    }
+
+    if (this.helpTooltip) {
+      this.map.instance.removeOverlay(this.helpTooltip);
+    }
+
+    if (this.measureTooltipElement) {
+      this.measureTooltipElement.remove();
+    }
+
+    if (this.helpTooltipElement) {
+      this.helpTooltipElement.remove();
+    }
+
+    if (this.vector && !this.source) {
+      this.map.instance.removeLayer(this.vector);
+    }
+  }
+}

--- a/libs/ng-openlayers/src/public-api.ts
+++ b/libs/ng-openlayers/src/public-api.ts
@@ -80,6 +80,7 @@ import { AttributionComponent } from './lib/attribution.component';
 import { SourceUTFGridComponent } from './lib/sources/utfgrid.component';
 import { LayerComponent } from './lib/layers/layer.component';
 import { DrawHoleInPolygonInteractionComponent } from './lib/interactions/draw-hole-in-polygon';
+import { MeasureInteractionComponent, MeasureType } from './lib/interactions/measure.component';
 
 export {
   MapComponent,
@@ -158,9 +159,13 @@ export {
   ContentComponent,
   AttributionsComponent,
   AttributionComponent,
+  DrawHoleInPolygonInteractionComponent,
+  MeasureInteractionComponent,
+  MeasureType,
 };
 
 export * from './lib/interactions/draw-hole-in-polygon';
+export * from './lib/interactions/measure.component';
 
 const COMPONENTS = [
   MapComponent,
@@ -239,6 +244,7 @@ const COMPONENTS = [
   ModifyInteractionComponent,
   TranslateInteractionComponent,
   DrawHoleInPolygonInteractionComponent,
+  MeasureInteractionComponent,
 
   OverlayComponent,
   ContentComponent,


### PR DESCRIPTION
### Description

This pull request introduces `aol-interaction-measure`, a new feature for measuring distances and areas on maps in the `ng-openlayers` library. Key additions include:

- Support for measuring both distances and areas.
- Dynamic tooltips and measurement controls.
- Compatibility with metric and imperial units.
- A new `MeasureComponent` example showcasing usage.
- Updates to routing and public API to include the new interaction. 

